### PR TITLE
Add a notice about decomissioning of the service.

### DIFF
--- a/contents/developers/index.ejs
+++ b/contents/developers/index.ejs
@@ -3,6 +3,17 @@
     * file, You can obtain one at http://mozilla.org/MPL/2.0/.*/ %>
 
 <div id="content" class="display_always">
+
+    <div class="notice">
+<p>Persona is no longer actively developed by Mozilla. Mozilla has committed to operational and security support of the persona.org services until November 30th, 2016.</p>
+
+<p class="summary">On November 30th, 2016, Mozilla will shut down the persona.org services. Persona.org and related domains will be taken offline.</p>
+
+<p>If you run a website that relies on Persona, you need to implement an alternative login solution for your users before this date.  For more information, see this guide to migrating your site away from Persona:</p>
+
+<p class="link"><a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers</a></p>
+    </div>
+
     <div class="about">
         <section class="simple-signon">
             <h1 class="title center">Stop worrying about storing passwords.</h1>

--- a/contents/index.ejs
+++ b/contents/index.ejs
@@ -3,6 +3,17 @@
     * file, You can obtain one at http://mozilla.org/MPL/2.0/.*/ %>
 
 <div id="content" class="display_always">
+
+    <div class="notice">
+<p>Persona is no longer actively developed by Mozilla. Mozilla has committed to operational and security support of the persona.org services until November 30th, 2016.</p>
+
+<p class="summary">On November 30th, 2016, Mozilla will shut down the persona.org services. Persona.org and related domains will be taken offline.</p>
+
+<p>If you run a website that relies on Persona, you need to implement an alternative login solution for your users before this date.  For more information, see this guide to migrating your site away from Persona:</p>
+
+<p class="link"><a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers</a></p>
+    </div>
+
     <div class="about">
         <section class="simple-signon">
             <h1 class="title center">Everybody hates passwords.</h1>

--- a/contents/providers/index.ejs
+++ b/contents/providers/index.ejs
@@ -3,6 +3,17 @@
     * file, You can obtain one at http://mozilla.org/MPL/2.0/.*/ %>
 
 <div id="content" class="display_always">
+
+    <div class="notice">
+<p>Persona is no longer actively developed by Mozilla. Mozilla has committed to operational and security support of the persona.org services until November 30th, 2016.</p>
+
+<p class="summary">On November 30th, 2016, Mozilla will shut down the persona.org services. Persona.org and related domains will be taken offline.</p>
+
+<p>If you run a website that relies on Persona, you need to implement an alternative login solution for your users before this date.  For more information, see this guide to migrating your site away from Persona:</p>
+
+<p class="link"><a href="https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers">https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers</a></p>
+    </div>
+
     <div class="about">
         <section class="simple-signon">
             <h1 class="title center"><%- gettext('Join a major password reset.') %></h1>

--- a/contents/static/css/style.css
+++ b/contents/static/css/style.css
@@ -1479,3 +1479,31 @@ section.light {
     color: #4D4E53;
 
 }
+
+#content .notice {
+    text-align: left;
+    background: #8A241B;
+    border: 1px solid #710B02;
+    padding: 5px;
+    padding-left: 15px;
+    padding-right: 15px;
+    margin-bottom: 30px;
+}
+
+#content .notice p {
+    padding: 0.4em;
+}
+
+#content .notice p.summary {
+    font-weight: bold;
+}
+
+#content .notice p.link {
+    text-align: center;
+}
+
+#content .notice p.link a {
+    color: #fff;
+    border-bottom: 1px dotted #fff;
+    font-weight: normal;
+}


### PR DESCRIPTION
Alrighty, here's my rather inelgant stab at adding a "persona is going away" notice to www.persona.org:

![screen shot 2016-01-14 at 12 58 15](https://cloud.githubusercontent.com/assets/34695/12337370/81118fdc-babe-11e5-9a1d-13f8af3f77a6.png)

/cc @zaach @ryanfeeley in case either of you would like to suggest some improvements :-)

We might also consider just removing all the existing content on these pages, as it's not really useful to anyone any more, leaving just a notice and link to more information.  But that seems like more major surgery and I'd rather get something out sooner than later.

@callahad f?
